### PR TITLE
Enable JSP support when running Main directly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <slf4j.version>1.7.7</slf4j.version>
     <logback.version>1.1.2</logback.version>
     <codahale.metrics.version>3.0.1</codahale.metrics.version>
-    <jetty.version>9.1.4.v20140401</jetty.version>
+    <jetty.version>9.2.1.v20140609</jetty.version>
     <junit.version>4.11</junit.version>
   </properties>
 
@@ -100,18 +100,6 @@
       <artifactId>javax.servlet-api</artifactId>
       <version>3.1.0</version>
     </dependency>
-    <dependency>
-      <groupId>javax.servlet.jsp</groupId>
-      <artifactId>jsp-api</artifactId>
-      <version>2.1</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>jstl</artifactId>
-      <version>1.2</version>
-      <scope>provided</scope>
-    </dependency>
 
     <!-- Requirements for embedded Jetty. -->
     <dependency>
@@ -121,8 +109,24 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-jsp</artifactId>
+      <artifactId>apache-jsp</artifactId>
       <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-annotations</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-plus</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>apache-jstl</artifactId>
+      <version>${jetty.version}</version>
+      <type>pom</type>
     </dependency>
 
     <!-- Coda Hale's metrics. -->

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
   <version>0.0.1-SNAPSHOT</version>
 
   <properties>
+     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.7</java.version>
     <springframework.version>4.0.3.RELEASE</springframework.version>
     <springsecurity.version>3.2.3.RELEASE</springsecurity.version>

--- a/src/main/java/ca/unx/template/Main.java
+++ b/src/main/java/ca/unx/template/Main.java
@@ -26,6 +26,7 @@
 package ca.unx.template;
 
 import ca.unx.template.config.RootConfiguration;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
@@ -54,7 +55,8 @@ public class Main {
         final Logger logger = LoggerFactory.getLogger("main");
 
         try {
-            AnnotationConfigApplicationContext applicationContext =
+            @SuppressWarnings("resource")
+			AnnotationConfigApplicationContext applicationContext =
                     new AnnotationConfigApplicationContext();
 
             /*

--- a/src/main/java/ca/unx/template/config/JettyConfiguration.java
+++ b/src/main/java/ca/unx/template/config/JettyConfiguration.java
@@ -25,10 +25,17 @@
 
 package ca.unx.template.config;
 
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.health.HealthCheckRegistry;
-import com.codahale.metrics.servlets.HealthCheckServlet;
-import com.codahale.metrics.servlets.MetricsServlet;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.jasper.servlet.JspServlet;
+import org.eclipse.jetty.annotations.ServletContainerInitializersStarter;
+import org.eclipse.jetty.apache.jsp.JettyJasperInitializer;
+import org.eclipse.jetty.plus.annotation.ContainerInitializer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletHolder;
@@ -42,7 +49,10 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.context.support.GenericWebApplicationContext;
 
-import java.io.IOException;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import com.codahale.metrics.servlets.HealthCheckServlet;
+import com.codahale.metrics.servlets.MetricsServlet;
 
 /**
  * Configure the embedded Jetty server and the SpringMVC dispatcher servlet.
@@ -50,72 +60,111 @@ import java.io.IOException;
 @Configuration
 public class JettyConfiguration {
 
-    @Autowired
-    private ApplicationContext applicationContext;
+	@Autowired
+	private ApplicationContext applicationContext;
 
-    @Autowired
-    private MetricRegistry metricRegistry;
+	@Autowired
+	private MetricRegistry metricRegistry;
 
-    @Autowired
-    private HealthCheckRegistry healthCheckRegistry;
+	@Autowired
+	private HealthCheckRegistry healthCheckRegistry;
 
-    @Value("${jetty.port:8080}")
-    private int jettyPort;
+	@Value("${jetty.port:8080}")
+	private int jettyPort;
 
-    @Bean
-    public WebAppContext jettyWebAppContext() throws IOException {
+	@Bean
+	public WebAppContext jettyWebAppContext() throws IOException {
 
-        WebAppContext ctx = new WebAppContext();
-        ctx.setContextPath("/");
-        ctx.setWar(new ClassPathResource("webapp").getURI().toString());
+		WebAppContext ctx = new WebAppContext();
+		ctx.setContextPath("/");
+		ctx.setWar(new ClassPathResource("webapp").getURI().toString());
 
-        /* Disable directory listings if no index.html is found. */
-        ctx.setInitParameter("org.eclipse.jetty.servlet.Default.dirAllowed",
-                "false");
+		/* Disable directory listings if no index.html is found. */
+		ctx.setInitParameter("org.eclipse.jetty.servlet.Default.dirAllowed", "false");
 
-        /* Create the root web application context and set it as a servlet
-         * attribute so the dispatcher servlet can find it. */
-        GenericWebApplicationContext webApplicationContext =
-                new GenericWebApplicationContext();
-        webApplicationContext.setParent(applicationContext);
-        webApplicationContext.refresh();
-        ctx.setAttribute(
-                WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE,
-                webApplicationContext);
+		configureJspSupport(ctx);
 
-        /*
-         * Set the attributes that the Metrics servlets require.  The Metrics
-         * servlet is added in the WebAppInitializer.
-         */
-        ctx.setAttribute(MetricsServlet.METRICS_REGISTRY,
-                metricRegistry);
-        ctx.setAttribute(HealthCheckServlet.HEALTH_CHECK_REGISTRY,
-                healthCheckRegistry);
+		/*
+		 * Create the root web application context and set it as a servlet attribute so the dispatcher servlet can find it.
+		 */
+		GenericWebApplicationContext webApplicationContext = new GenericWebApplicationContext();
+		webApplicationContext.setParent(applicationContext);
+		webApplicationContext.refresh();
+		ctx.setAttribute(WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, webApplicationContext);
 
-        ctx.addEventListener(new WebAppInitializer());
+		/*
+		 * Set the attributes that the Metrics servlets require. The Metrics servlet is added in the WebAppInitializer.
+		 */
+		ctx.setAttribute(MetricsServlet.METRICS_REGISTRY, metricRegistry);
+		ctx.setAttribute(HealthCheckServlet.HEALTH_CHECK_REGISTRY, healthCheckRegistry);
 
-        return ctx;
-    }
+		ctx.addEventListener(new WebAppInitializer());
 
-    /**
-     * Jetty Server bean.
-     * <p/>
-     * Instantiate the Jetty server.
-     */
-    @Bean(initMethod = "start", destroyMethod = "stop")
-    public Server jettyServer() throws IOException {
+		return ctx;
+	}
 
-        /* Create the server. */
-        Server server = new Server();
+	private void configureJspSupport(WebAppContext context) {
+		File tempDir = new File(System.getProperty("java.io.tmpdir"));
+		File scratchDir = new File(tempDir.toString(), "embedded-jetty-jsp");
 
-        /* Create a basic connector. */
-        ServerConnector httpConnector = new ServerConnector(server);
-        httpConnector.setPort(jettyPort);
-        server.addConnector(httpConnector);
+		if (!scratchDir.exists()) {
+			if (!scratchDir.mkdirs()) {
+				throw new RuntimeException("Unable to create scratch directory: " + scratchDir);
+			}
+		}
+		context.setAttribute("javax.servlet.context.tempdir", scratchDir);
+//		System.setProperty("org.apache.jasper.compiler.disablejsr199", "false");
+		// context.setAttribute(InstanceManager.class.getName(), new SimpleInstanceManager());
 
-        server.setHandler(jettyWebAppContext());
+		// Ensure the jsp engine is initialized correctly
+		JettyJasperInitializer sci = new JettyJasperInitializer();
+		ServletContainerInitializersStarter sciStarter = new ServletContainerInitializersStarter(context);
+		ContainerInitializer initializer = new ContainerInitializer(sci, null);
+		List<ContainerInitializer> initializers = new ArrayList<ContainerInitializer>();
+		initializers.add(initializer);
 
-        return server;
-    }
+		context.setAttribute("org.eclipse.jetty.containerInitializers", initializers);
+		context.addBean(sciStarter, true);
+
+		// Set Classloader of Context to be sane (needed for JSTL)
+		// JSP requires a non-System classloader, this simply wraps the
+		// embedded System classloader in a way that makes it suitable
+		// for JSP to use
+		ClassLoader jspClassLoader = new URLClassLoader(new URL[0], this.getClass().getClassLoader());
+		context.setClassLoader(jspClassLoader);
+
+		// Add JSP Servlet (must be named "jsp")
+		ServletHolder holderJsp = new ServletHolder("jsp", JspServlet.class);
+		holderJsp.setInitOrder(0);
+		holderJsp.setInitParameter("logVerbosityLevel", "DEBUG");
+		holderJsp.setInitParameter("fork", "false");
+		holderJsp.setInitParameter("xpoweredBy", "false");
+		holderJsp.setInitParameter("compilerTargetVM", "1.7");
+		holderJsp.setInitParameter("compilerSourceVM", "1.7");
+		holderJsp.setInitParameter("keepgenerated", "true");
+		context.addServlet(holderJsp, "*.jsp");
+
+	}
+
+	/**
+	 * Jetty Server bean.
+	 * <p/>
+	 * Instantiate the Jetty server.
+	 */
+	@Bean(initMethod = "start", destroyMethod = "stop")
+	public Server jettyServer() throws IOException {
+
+		/* Create the server. */
+		Server server = new Server();
+
+		/* Create a basic connector. */
+		ServerConnector httpConnector = new ServerConnector(server);
+		httpConnector.setPort(jettyPort);
+		server.addConnector(httpConnector);
+
+		server.setHandler(jettyWebAppContext());
+
+		return server;
+	}
 
 }

--- a/src/main/java/ca/unx/template/config/MvcConfiguration.java
+++ b/src/main/java/ca/unx/template/config/MvcConfiguration.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;

--- a/src/main/java/ca/unx/template/config/WebAppInitializer.java
+++ b/src/main/java/ca/unx/template/config/WebAppInitializer.java
@@ -25,18 +25,18 @@
 
 package ca.unx.template.config;
 
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.health.HealthCheckRegistry;
-import com.codahale.metrics.servlets.AdminServlet;
-import com.codahale.metrics.servlets.HealthCheckServlet;
-import com.codahale.metrics.servlets.MetricsServlet;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRegistration;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.filter.DelegatingFilterProxy;
 import org.springframework.web.servlet.support.AbstractAnnotationConfigDispatcherServletInitializer;
 
-import javax.servlet.*;
+import com.codahale.metrics.servlets.AdminServlet;
 
 public class WebAppInitializer extends
         AbstractAnnotationConfigDispatcherServletInitializer implements

--- a/src/main/resources/logback.groovy
+++ b/src/main/resources/logback.groovy
@@ -28,6 +28,8 @@ logger("org.eclipse.jetty.webapp.WebAppClassLoader", INFO)
 logger("org.eclipse.jetty.util.resource.JarResource", INFO)
 
 /* Quieten Jetty in general. */
+logger("org.apache.tomcat", INFO)
+logger("org.apache.jasper", INFO)
 logger("org.eclipse", ERROR);
 
 def appenders = []


### PR DESCRIPTION
I've been looking for a way to configure embedded jetty w/ JSP compilation at runtime that doesn't also require the JDK.
The Jetty project has an example here: https://github.com/jetty-project/embedded-jetty-jsp

I've incorporated the JSP servlet configuration into this template project. This is the Jetty 9.2 way, which uses jasper from apache-jsp instead of the glassfish jars.
